### PR TITLE
重新加载logback配置文件，LoggerContext需要reset。

### DIFF
--- a/src/main/java/com/alibaba/middleware/innerlog/LoggerFactory.java
+++ b/src/main/java/com/alibaba/middleware/innerlog/LoggerFactory.java
@@ -121,6 +121,9 @@ public class LoggerFactory {
 			try {
 				Class<?> JoranConfClass = ClassUtils.getClass(loggerClassLoader,
 						"ch.qos.logback.classic.joran.JoranConfigurator");
+				// 重新设置LoggerContext
+				MethodUtils.invokeMethod( loggerClassLoader.getInnerFactory(), "reset",
+						ArrayUtils.EMPTY_OBJECT_ARRAY);
 				Object JoranConfObj = ConstructorUtils.invokeConstructor(
 						JoranConfClass, ArrayUtils.EMPTY_OBJECT_ARRAY);
 				// 设置logContext


### PR DESCRIPTION
### 现象

```
 String key = "demo";
 LoggerFactory.doConfigure(new DefaultLogConfigure("inner-default-logback.xml"), key);
Logger logger = LoggerFactory.getLogger(LoggerFactory.class, key);
logger.warn("hello");
```
执行这个代码，理论上日志会输出到 ~/logs/default.log下，但是控制台也会输出一份。

## 分析
我分析的原因是LoggerFactory在初始化的时候（使用反射生成这个类的时候），由于没有logback.xml等配置文件的存在，会有一个默认的配置
ch.qos.logback.classic.util.ContextInitializer#autoConfig
```
  public void autoConfig() throws JoranException {
    StatusListenerConfigHelper.installIfAsked(loggerContext);
    URL url = findURLOfDefaultConfigurationFile(true);
    if (url != null) {
      configureByResource(url);
    } else {
      BasicConfigurator.configure(loggerContext);
    }
  }
```
你的LoggerFactory添加新建了一个JoranConfigurator，所以也会输出到文件。

### 解决方法及参考

```
LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
loggerContext.reset();
JoranConfigurator configurator = new JoranConfigurator();
InputStream configStream = FileUtils.openInputStream(logbackPropertiesUserFile);
configurator.setContext(loggerContext);
configurator.doConfigure(configStream); // loads logback file
configStream.close();
```

http://stackoverflow.com/questions/21885787/setting-logback-xml-path-programmatically

